### PR TITLE
Condense UI

### DIFF
--- a/src/components/groups/GroupOverview.tsx
+++ b/src/components/groups/GroupOverview.tsx
@@ -1,6 +1,8 @@
 import AddPlayerDialog from '~/components/groups/AddPlayerDialog';
 import ImageUploadDialog from '~/components/groups/ImageUploadDialog';
-import PlayerList from '~/components/groups/PlayerList';
+import NeedsSignupList from '~/components/groups/NeedsSignupList';
+import OurCourtsList from '~/components/groups/OurCourtsList';
+import ShowAllPlayersDialog from '~/components/groups/ShowAllPlayersDialog';
 import SignupTable from '~/components/groups/SignupTable';
 import { Button } from '~/components/ui/button';
 import { useToast } from '~/components/ui/use-toast';
@@ -65,7 +67,7 @@ const GroupOverview = (props: Props) => {
   }
 
   return (
-    <div className="flex flex-col items-stretch justify-center gap-12">
+    <div className="flex flex-col items-stretch justify-center gap-4">
       <div className="flex flex-col gap-4">
         <div className="flex items-center gap-4 mx-auto justify-center">
           <div className="flex flex-col">
@@ -77,19 +79,32 @@ const GroupOverview = (props: Props) => {
           <Button onClick={handleCopyLink}>Copy link</Button>
         </div>
       </div>
-      <div>
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <h2 className="text-2xl">Players</h2>
-            <p>{playerQuery.data?.length} total</p>
-          </div>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <p>{playerQuery.data?.length} players</p>
+        </div>
+        <div className="flex gap-2">
+          <ShowAllPlayersDialog
+            groupId={groupId}
+            playerQuery={playerQuery}
+            signupStateQuery={signupStateQuery}
+          />
           <AddPlayerDialog
             groupId={groupId}
             onPlayerAdd={playerQuery.refetch}
           />
         </div>
-        <PlayerList
-          groupId={groupId}
+      </div>
+      <div className="flex flex-col">
+        <h2 className="text-2xl">Needs signup</h2>
+        <NeedsSignupList
+          playerQuery={playerQuery}
+          signupStateQuery={signupStateQuery}
+        />
+      </div>
+      <div className="flex flex-col">
+        <h2 className="text-2xl">Our courts</h2>
+        <OurCourtsList
           playerQuery={playerQuery}
           signupStateQuery={signupStateQuery}
         />
@@ -97,7 +112,7 @@ const GroupOverview = (props: Props) => {
       <div>
         <div className="flex flex-col items-stretch justify-center gap-12">
           <div className="flex items-center justify-between">
-            <h2 className="text-2xl">Courts</h2>
+            <h2 className="text-2xl">All Courts</h2>
             <div className="flex items-center gap-2">
               <ImageUploadDialog
                 groupId={groupId}

--- a/src/components/groups/NeedsSignupList.tsx
+++ b/src/components/groups/NeedsSignupList.tsx
@@ -1,0 +1,101 @@
+import { type TRPCClientErrorLike } from '@trpc/client';
+import { type UseTRPCQueryResult } from '@trpc/react-query/shared';
+import { type inferRouterOutputs } from '@trpc/server';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '~/components/ui/table';
+import { type AppRouter } from '~/server/api/root';
+import * as React from 'react';
+
+type Props = {
+  playerQuery: UseTRPCQueryResult<
+    inferRouterOutputs<AppRouter>['players']['getPlayers'],
+    TRPCClientErrorLike<AppRouter>
+  >;
+  signupStateQuery: UseTRPCQueryResult<
+    inferRouterOutputs<AppRouter>['signups']['getSignupState'],
+    TRPCClientErrorLike<AppRouter>
+  >;
+};
+
+const NeedsSignupList = (props: Props) => {
+  const { playerQuery, signupStateQuery } = props;
+
+  if (playerQuery.isLoading || signupStateQuery.isLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center">
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  if (playerQuery.isError) {
+    return (
+      <div className="flex flex-col items-center justify-center">
+        <p>Something went wrong!</p>
+        <p>{playerQuery?.error?.message}</p>
+      </div>
+    );
+  }
+
+  if (signupStateQuery.isError) {
+    return (
+      <div className="flex flex-col items-center justify-center">
+        <p>Something went wrong!</p>
+        <p>{signupStateQuery?.error?.message}</p>
+      </div>
+    );
+  }
+
+  // find players that aren't in the signup
+
+  const players = playerQuery.data;
+  const playersSignedUp = new Set<string>();
+  signupStateQuery.data?.signupsByCourt.forEach((signups, court) => {
+    signups.forEach((signup) => {
+      signup.players.forEach((player) =>
+        playersSignedUp.add(player.toLowerCase()),
+      );
+    });
+  });
+
+  const playersNotSignedUp: { username: string; password: string }[] = [];
+  players.forEach((player) => {
+    if (!playersSignedUp.has(player.username.toLowerCase())) {
+      playersNotSignedUp.push({
+        username: player.username,
+        password: player.password,
+      });
+    }
+  });
+
+  playersNotSignedUp.sort((a, b) =>
+    new Intl.Collator().compare(a.username, b.username),
+  );
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="p-2">Username</TableHead>
+          <TableHead className="p-2">Password</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {playersNotSignedUp.map((player, i) => (
+          <TableRow key={i}>
+            <TableCell className="p-2">{player.username}</TableCell>
+            <TableCell className="p-2">{player.password}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+
+export default NeedsSignupList;

--- a/src/components/groups/OurCourtsList.tsx
+++ b/src/components/groups/OurCourtsList.tsx
@@ -1,0 +1,141 @@
+import { type TRPCClientErrorLike } from '@trpc/client';
+import { type UseTRPCQueryResult } from '@trpc/react-query/shared';
+import { type inferRouterOutputs } from '@trpc/server';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '~/components/ui/table';
+import { type AppRouter } from '~/server/api/root';
+import { formatTime } from '~/utils/time';
+import * as React from 'react';
+
+type Props = {
+  playerQuery: UseTRPCQueryResult<
+    inferRouterOutputs<AppRouter>['players']['getPlayers'],
+    TRPCClientErrorLike<AppRouter>
+  >;
+  signupStateQuery: UseTRPCQueryResult<
+    inferRouterOutputs<AppRouter>['signups']['getSignupState'],
+    TRPCClientErrorLike<AppRouter>
+  >;
+};
+
+const OurCourtsList = (props: Props) => {
+  const { playerQuery, signupStateQuery } = props;
+
+  if (playerQuery.isLoading || signupStateQuery.isLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center">
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  if (playerQuery.isError) {
+    return (
+      <div className="flex flex-col items-center justify-center">
+        <p>Something went wrong!</p>
+        <p>{playerQuery?.error?.message}</p>
+      </div>
+    );
+  }
+
+  if (signupStateQuery.isError) {
+    return (
+      <div className="flex flex-col items-center justify-center">
+        <p>Something went wrong!</p>
+        <p>{signupStateQuery?.error?.message}</p>
+      </div>
+    );
+  }
+
+  // Find signups that contain a name that's part of our group.
+  const playerNames = new Set<string>(
+    playerQuery.data.map((player) => player.username),
+  );
+  const ourSignups: {
+    court: string;
+    players: string[];
+    onCourt: boolean;
+    sortIndex: number;
+  }[] = [];
+  signupStateQuery.data?.signupsByCourt.forEach((signups, court) => {
+    signups.forEach((signup) => {
+      if (signup.players.some((player) => playerNames.has(player))) {
+        let status;
+        let sortIndex;
+        let onCourt = false;
+        if (signup.startsAt === null) {
+          status = 'after res';
+          sortIndex = Number.MAX_SAFE_INTEGER;
+        } else if (signup.startsAt < new Date()) {
+          status = `until ${formatTime(signup.endsAt!)}`;
+          sortIndex = signup.startsAt.getTime();
+          onCourt = true;
+        } else {
+          status = `at ${formatTime(signup.startsAt)}`;
+          sortIndex = signup.startsAt.getTime();
+        }
+        ourSignups.push({
+          court: `${court} ${status}`,
+          players: signup.players,
+          onCourt,
+          sortIndex,
+        });
+      }
+    });
+  });
+
+  ourSignups.sort((a, b) => a.sortIndex - b.sortIndex);
+
+  const formatPlayers = (players: string[]) => {
+    return (
+      <div className="grid grid-cols-2 gap-1">
+        {players.map((player, i) => {
+          if (playerNames.has(player)) {
+            return (
+              <div key={i} className="text-green-300">
+                {player}
+              </div>
+            );
+          }
+          return <div key={i}>{player}</div>;
+        })}
+      </div>
+    );
+  };
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="p-2">Court</TableHead>
+          <TableHead className="p-2">Players</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {ourSignups.map((signup, i) => (
+          <TableRow key={i}>
+            {signup.onCourt ? (
+              <TableCell className="p-2 text-green-300">
+                {signup.court}
+              </TableCell>
+            ) : (
+              <TableCell className="p-2">{signup.court}</TableCell>
+            )}
+
+            <TableCell className="py-2">
+              {formatPlayers(signup.players)}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+
+export default OurCourtsList;

--- a/src/components/groups/PlayerList.tsx
+++ b/src/components/groups/PlayerList.tsx
@@ -78,37 +78,33 @@ const PlayerList = (props: Props) => {
   const formattedPlayers = players.map((p) => {
     const signup = playerStatus.get(p.username.toLowerCase());
     let status;
-    let sortIndex;
 
     if (signup == null) {
       status = 'Needs sign up';
-      sortIndex = 0;
     } else {
       const { startsAt, endsAt, court } = signup;
       if (startsAt == null) {
         status = `On ${court} after res`;
-        sortIndex = Number.MAX_SAFE_INTEGER;
       } else if (startsAt < new Date()) {
         status = `On ${court} until ${formatTime(endsAt!)}`;
-        sortIndex = startsAt.getTime();
       } else {
         status = `Waiting for ${court}, on at ${formatTime(startsAt)}`;
-        sortIndex = startsAt.getTime();
       }
     }
 
     return {
       username: p.username,
       password: p.password,
-      sortIndex,
       status,
     };
   });
 
-  formattedPlayers.sort((a, b) => a.sortIndex - b.sortIndex);
+  formattedPlayers.sort((a, b) =>
+    new Intl.Collator().compare(a.username, b.username),
+  );
 
   return (
-    <Table>
+    <Table className="block overflow-y-scroll max-h-96">
       <TableHeader>
         <TableRow>
           <TableHead>Username</TableHead>

--- a/src/components/groups/ShowAllPlayersDialog.tsx
+++ b/src/components/groups/ShowAllPlayersDialog.tsx
@@ -1,0 +1,58 @@
+import { type TRPCClientErrorLike } from '@trpc/client';
+import { type UseTRPCQueryResult } from '@trpc/react-query/dist/shared';
+import { type inferRouterOutputs } from '@trpc/server';
+import PlayerList from '~/components/groups/PlayerList';
+import { Button } from '~/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '~/components/ui/dialog';
+import { type AppRouter } from '~/server/api/root';
+import * as React from 'react';
+
+type Props = {
+  groupId: string;
+  playerQuery: UseTRPCQueryResult<
+    inferRouterOutputs<AppRouter>['players']['getPlayers'],
+    TRPCClientErrorLike<AppRouter>
+  >;
+  signupStateQuery: UseTRPCQueryResult<
+    inferRouterOutputs<AppRouter>['signups']['getSignupState'],
+    TRPCClientErrorLike<AppRouter>
+  >;
+};
+
+const ShowAllPlayersDialog = (props: Props) => {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>Show All</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>All Players</DialogTitle>
+        </DialogHeader>
+        <PlayerList {...props} />
+        <DialogFooter>
+          <div className="flex justify-end">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setOpen(false);
+              }}
+            >
+              Close
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ShowAllPlayersDialog;


### PR DESCRIPTION
Condenses the UI by organizing into:
* Needs signup section
* Our courts section
* Reducing padding on table cells

Before:
<img width="405" alt="Screenshot 2023-08-13 at 12 31 37 PM" src="https://github.com/pohang/baddybuddy/assets/19980697/9eede416-da83-4684-8fe3-e6b14fd070f3">

After:
<img width="399" alt="Screenshot 2023-08-13 at 12 31 28 PM" src="https://github.com/pohang/baddybuddy/assets/19980697/0fc9e1ab-9642-4ec1-8553-fad6f8fddf14">

The original PlayerList component was moved under a Show All players dialog.

